### PR TITLE
Override github login. Fixes issue #8

### DIFF
--- a/templates/account/login.html
+++ b/templates/account/login.html
@@ -9,10 +9,10 @@
   <form method="post">
     {% csrf_token %}
     {{ form|crispy }}
-    <button class="btn btn-success btn-block" type="submit">Log In</button>
+    <button class="btn btn-success" type="submit">Log In</button>
   </form>
-  <p class="text-center text-muted">OR</p>
-  <a class="btn btn-dark btn-block" href="{% provider_login_url 'github' %}">Continue with GitHub</a>
+  <p class="text-left text-muted">OR</p>
+  <a class="btn btn-dark" href="{% provider_login_url 'github' %}">Continue with GitHub</a>
   <p class="text-center mt-3">
     New to Django Polls?
     <a href="{% url 'account_signup' %}">Sign Up</a>

--- a/templates/socialaccount/login.html
+++ b/templates/socialaccount/login.html
@@ -1,0 +1,13 @@
+{% extends 'base.html' %}
+{% load crispy_forms_tags %}
+
+{% block title %}Sign In Via GitHub{% endblock title %}
+
+{% block content %}
+  <h2>Sign In Via GitHub</h2>
+  <p>You are about to sign in using a third party account from GitHub.</p>
+  <form method="post">
+    {% csrf_token %}
+    <button class="btn btn-success" type="submit">Continue</button>
+  </form>
+{% endblock content %}


### PR DESCRIPTION
Create template to override allauth's default template used when signing on with GitHub auth